### PR TITLE
Add support for Python 3

### DIFF
--- a/gpsoauth/__init__.py
+++ b/gpsoauth/__init__.py
@@ -6,10 +6,10 @@ from . import google
 
 # The key is distirbuted with Google Play Services.
 # This one is from version 7.3.29.
-b64_key_7_3_29 = ("AAAAgMom/1a/v0lblO2Ubrt60J2gcuXSljGFQXgcyZWveWLEwo6prwgi3"
-                  "iJIZdodyhKZQrNWp5nKJ3srRXcUW+F1BD3baEVGcmEgqaLZUNBjm057pK"
-                  "RI16kB0YppeGx5qIQ5QjKzsR8ETQbKLNWgRY0QRNVz34kMJR3P/LgHax/"
-                  "6rmf5AAAAAwEAAQ==")
+b64_key_7_3_29 = (b"AAAAgMom/1a/v0lblO2Ubrt60J2gcuXSljGFQXgcyZWveWLEwo6prwgi3"
+                  b"iJIZdodyhKZQrNWp5nKJ3srRXcUW+F1BD3baEVGcmEgqaLZUNBjm057pK"
+                  b"RI16kB0YppeGx5qIQ5QjKzsR8ETQbKLNWgRY0QRNVz34kMJR3P/LgHax/"
+                  b"6rmf5AAAAAwEAAQ==")
 
 android_key_7_3_29 = google.key_from_b64(b64_key_7_3_29)
 

--- a/gpsoauth/google.py
+++ b/gpsoauth/google.py
@@ -25,7 +25,7 @@ def key_to_struct(key):
     mod = long_to_bytes(key.n)
     exponent = long_to_bytes(key.e)
 
-    return '\x00\x00\x00\x80' + mod + '\x00\x00\x00\x03' + exponent
+    return b'\x00\x00\x00\x80' + mod + b'\x00\x00\x00\x03' + exponent
 
 
 def parse_auth_response(text):
@@ -41,8 +41,7 @@ def parse_auth_response(text):
 
 
 def signature(email, password, key):
-    signature = []
-    signature.append('\x00')
+    signature = bytearray(b'\x00')
 
     struct = key_to_struct(key)
     signature.extend(hashlib.sha1(struct).digest()[:4])
@@ -52,4 +51,4 @@ def signature(email, password, key):
 
     signature.extend(encrypted_login)
 
-    return base64.urlsafe_b64encode(''.join(signature))
+    return base64.urlsafe_b64encode(signature)

--- a/gpsoauth/tests.py
+++ b/gpsoauth/tests.py
@@ -1,0 +1,13 @@
+from gpsoauth.google import signature
+from gpsoauth.util import bytes_to_long, long_to_bytes
+from gpsoauth import android_key_7_3_29, b64_key_7_3_29
+
+
+def test_static_signature():
+    username = "someone@google.com"
+    password = "apassword"
+    assert signature(username, password, android_key_7_3_29).startswith(b"AFcb4K")
+
+
+def test_conversion_roundtrip():
+    assert long_to_bytes(bytes_to_long(b64_key_7_3_29)) == b64_key_7_3_29

--- a/gpsoauth/util.py
+++ b/gpsoauth/util.py
@@ -1,7 +1,12 @@
 import binascii
+import sys
+
+PY3 = sys.version[0] == '3'
 
 
 def bytes_to_long(s):
+    if PY3:
+        return int.from_bytes(s, "big")
     return long(s.encode('hex'), 16)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py34, py35
+
+[testenv]
+commands = py.test gpsoauth/tests.py
+deps = pytest


### PR DESCRIPTION
This doesn't use any of the big compatibility libraries, since the only real thing that needs smoothing over is the long/int change

Add very basic tests using py.test and tox