### PR TITLE
Specify Python 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
     ),
 )


### PR DESCRIPTION
Sorry, I should have included this yesterday.

I specifically tested on Python 3.4 and Python 3.5, so I can specify those minor versions if you want. Even though I didn't test on older versions, it _probably_ would work (?), but maybe it's better only to list the minor versions that are listed in tox or something.

I'm not really all that familiar with the customary way to use these trove classifiers in public projects, so just let me know whatever you think is best.