### PR TITLE
Switch from PyCrypto to PyCryptodome [#4]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ndg-httpsclient==0.4.0
 pyOpenSSL==0.15.1
 pyasn1==0.1.7
 pycparser==2.14
-pycrypto==2.6.1
+pycryptodome==3.3.1
 requests==2.7.0
 six==1.9.0
 wsgiref==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=['gpsoauth'],
     include_package_data=True,
     install_requires=[
-        'pycrypto >= 2.5',
+        'pycryptodome >= 3.0',
         'requests',
         'pyopenssl',
         'ndg-httpsclient',


### PR DESCRIPTION
As discussed, PyCryptodome is, as of now, a drop-in replacement fork of PyCrypto that is actively developed/maintained and provides wheels for Windows which solves some install troubles for users of that OS.