### PR TITLE
Use pycryptodomex instead of pycryptodome

### DIFF
--- a/gpsoauth/google.py
+++ b/gpsoauth/google.py
@@ -1,8 +1,8 @@
 import base64
 import hashlib
 
-from Crypto.PublicKey import RSA
-from Crypto.Cipher import PKCS1_OAEP
+from Cryptodome.PublicKey import RSA
+from Cryptodome.Cipher import PKCS1_OAEP
 
 from .util import bytes_to_long, long_to_bytes
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pycryptodome==3.4
+pycryptodomex==3.4
 requests==2.9.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=['gpsoauth'],
     include_package_data=True,
     install_requires=[
-        'pycryptodome >= 3.0',
+        'pycryptodomex >= 3.0',
         'requests',
     ],
     license='MIT',


### PR DESCRIPTION
This prevents weird conflicts when other dependencies of an app require the old PyCrypto and use features that have been renamed (or otherwise) in PyCryptodome.

As an example, I'm trying to use gmusicapi and [keyring](https://pypi.python.org/pypi/keyring) (with [SecretStorage](https://pypi.python.org/pypi/SecretStorage)) together. SecretStorage requires PyCrypto and uses an API that was renamed in PyCryptodome: `Crypto.Cipher.AES.AESCipher` :arrow_right: `Crypto.Cipher.AES.new`.