### PR TITLE
Update README to include link to Ruby port

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,3 +10,4 @@ Many thanks to Dima Kovalenko for reverse engieering the EncryptedPasswd signatu
 Ports
 -----
 * C#: https://github.com/vemacs/GPSOAuthSharp.
+* Ruby: https://github.com/bryanmytko/gpsoauth


### PR DESCRIPTION
I ported this to Ruby to work on some Pokemon Go stuff. I figured since you had the C# link you might want to also include the Ruby version. 