### PR TITLE
Add type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,11 @@ repos:
         language: system
         types: [python]
         require_serial: true
+      - id: mypy
+        name: mypy
+        entry: poetry run mypy
+        language: system
+        types: [python]
       - id: flake8
         name: flake8
         entry: poetry run flake8

--- a/gpsoauth/__init__.py
+++ b/gpsoauth/__init__.py
@@ -1,10 +1,14 @@
 """A python client library for Google Play Services OAuth."""
-import ssl
+from __future__ import annotations
 
-from importlib_metadata import version
+from collections.abc import MutableMapping
+from importlib.metadata import version
+import ssl
+from typing import Any, Iterable
+
 import requests
-from urllib3.poolmanager import PoolManager
-from urllib3.util.ssl_ import DEFAULT_CIPHERS
+from urllib3.poolmanager import PoolManager  # type: ignore
+from urllib3.util.ssl_ import DEFAULT_CIPHERS  # type: ignore
 
 from . import google
 
@@ -34,7 +38,7 @@ CIPHERS = ":".join(
 class SSLContext(ssl.SSLContext):
     """SSLContext wrapper."""
 
-    def set_alpn_protocols(self, alpn_protocols):
+    def set_alpn_protocols(self, alpn_protocols: Iterable[str]) -> None:
         """
         ALPN headers cause Google to return 403 Bad Authentication.
         """
@@ -43,7 +47,7 @@ class SSLContext(ssl.SSLContext):
 class AuthHTTPAdapter(requests.adapters.HTTPAdapter):
     """HTTPAdapter wrapper."""
 
-    def init_poolmanager(self, *args, **kwargs):
+    def init_poolmanager(self, *args: Any, **kwargs: Any) -> None:
         """
         Secure settings from ssl.create_default_context(), but without
         ssl.OP_NO_TICKET which causes Google to return 403 Bad
@@ -59,11 +63,13 @@ class AuthHTTPAdapter(requests.adapters.HTTPAdapter):
         self.poolmanager = PoolManager(*args, ssl_context=context, **kwargs)
 
 
-def _perform_auth_request(data, proxy=None):
+def _perform_auth_request(
+    data: dict[str, int | str | bytes], proxies: MutableMapping[str, str] | None = None
+) -> dict[str, str]:
     session = requests.session()
     session.mount(AUTH_URL, AuthHTTPAdapter())
-    if proxy:
-        session.proxies = proxy
+    if proxies:
+        session.proxies = proxies
 
     res = session.post(AUTH_URL, data, headers={"User-Agent": USER_AGENT})
 
@@ -71,16 +77,16 @@ def _perform_auth_request(data, proxy=None):
 
 
 def perform_master_login(
-    email,
-    password,
-    android_id,
-    service="ac2dm",
-    device_country="us",
-    operator_country="us",
-    lang="en",
-    sdk_version=17,
-    proxy=None,
-):
+    email: str,
+    password: str,
+    android_id: str,
+    service: str = "ac2dm",
+    device_country: str = "us",
+    operator_country: str = "us",
+    lang: str = "en",
+    sdk_version: int = 17,
+    proxy: MutableMapping[str, str] | None = None,
+) -> dict[str, str]:
     """
     Perform a master login, which is what Android does when you first add
     a Google account.
@@ -103,7 +109,7 @@ def perform_master_login(
         }
     """
 
-    data = {
+    data: dict[str, int | str | bytes] = {
         "accountType": "HOSTED_OR_GOOGLE",
         "Email": email,
         "has_permission": 1,
@@ -124,18 +130,18 @@ def perform_master_login(
 
 
 def perform_oauth(
-    email,
-    master_token,
-    android_id,
-    service,
-    app,
-    client_sig,
-    device_country="us",
-    operator_country="us",
-    lang="en",
-    sdk_version=17,
-    proxy=None,
-):
+    email: str,
+    master_token: str,
+    android_id: str,
+    service: str,
+    app: str,
+    client_sig: str,
+    device_country: str = "us",
+    operator_country: str = "us",
+    lang: str = "en",
+    sdk_version: int = 17,
+    proxy: MutableMapping[str, str] | None = None,
+) -> dict[str, str]:
     """
     Use a master token from master_login to perform OAuth to a specific Google service.
 
@@ -153,7 +159,7 @@ def perform_oauth(
     ``Authorization: GoogleLogin auth=res['Auth']``.
     """
 
-    data = {
+    data: dict[str, int | str | bytes] = {
         "accountType": "HOSTED_OR_GOOGLE",
         "Email": email,
         "has_permission": 1,

--- a/gpsoauth/google.py
+++ b/gpsoauth/google.py
@@ -1,14 +1,17 @@
 """Functions to work with Google authentication structures."""
+from __future__ import annotations
+
 import base64
 import hashlib
 
 from Cryptodome.Cipher import PKCS1_OAEP
 from Cryptodome.PublicKey import RSA
+from Cryptodome.PublicKey.RSA import RsaKey
 
 from .util import bytes_to_int, int_to_bytes
 
 
-def key_from_b64(b64_key):
+def key_from_b64(b64_key: bytes) -> RsaKey:
     """Extract key from base64."""
     binary_key = base64.b64decode(b64_key)
 
@@ -23,7 +26,7 @@ def key_from_b64(b64_key):
     return key
 
 
-def key_to_struct(key):
+def key_to_struct(key: RsaKey) -> bytes:
     """Convert key to struct."""
     mod = int_to_bytes(key.n)
     exponent = int_to_bytes(key.e)
@@ -31,7 +34,7 @@ def key_to_struct(key):
     return b"\x00\x00\x00\x80" + mod + b"\x00\x00\x00\x03" + exponent
 
 
-def parse_auth_response(text):
+def parse_auth_response(text: str) -> dict[str, str]:
     """Parse received auth response."""
     response_data = {}
     for line in text.split("\n"):
@@ -44,7 +47,7 @@ def parse_auth_response(text):
     return response_data
 
 
-def construct_signature(email, password, key):
+def construct_signature(email: str, password: str, key: RsaKey) -> bytes:
     """Construct signature."""
     signature = bytearray(b"\x00")
 
@@ -52,7 +55,7 @@ def construct_signature(email, password, key):
     signature.extend(hashlib.sha1(struct).digest()[:4])
 
     cipher = PKCS1_OAEP.new(key)
-    encrypted_login = cipher.encrypt((email + u"\x00" + password).encode("utf-8"))
+    encrypted_login = cipher.encrypt((email + "\x00" + password).encode("utf-8"))
 
     signature.extend(encrypted_login)
 

--- a/gpsoauth/util.py
+++ b/gpsoauth/util.py
@@ -2,12 +2,12 @@
 import binascii
 
 
-def bytes_to_int(bytes_seq):
+def bytes_to_int(bytes_seq: bytes) -> int:
     """Convert bytes to int."""
     return int.from_bytes(bytes_seq, "big")
 
 
-def int_to_bytes(num, pad_multiple=1):
+def int_to_bytes(num: int, pad_multiple: int = 1) -> bytes:
     """Packs the num into a byte string 0 padded to a multiple of pad_multiple
     bytes in size. 0 means no padding whatsoever, so that packing 0 result
     in an empty string. The resulting byte string is the big-endian two's
@@ -19,11 +19,11 @@ def int_to_bytes(num, pad_multiple=1):
         return b"\0" * pad_multiple
     if num < 0:
         raise ValueError("Can only convert non-negative numbers.")
-    result = hex(num)[2:]
-    result = result.rstrip("L")
-    if len(result) & 1:
-        result = "0" + result
-    result = binascii.unhexlify(result)
+    value = hex(num)[2:]
+    value = value.rstrip("L")
+    if len(value) & 1:
+        value = "0" + value
+    result = binascii.unhexlify(value)
     if pad_multiple not in [0, 1]:
         filled_so_far = len(result) % pad_multiple
         if filled_so_far != 0:

--- a/poetry.lock
+++ b/poetry.lock
@@ -24,7 +24,6 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0"
-typed-ast = {version = ">=1.4.0,<1.5", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
 wrapt = ">=1.11,<1.13"
 
 [[package]]
@@ -60,7 +59,6 @@ python-versions = ">=3.6"
 [package.dependencies]
 appdirs = "*"
 click = ">=7.1.2"
-dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.6,<1"
 regex = ">=2020.1.8"
@@ -113,14 +111,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-name = "dataclasses"
-version = "0.8"
-description = "A backport of the dataclasses module for Python 3.6"
-category = "dev"
-optional = false
-python-versions = ">=3.6, <3.7"
-
-[[package]]
 name = "distlib"
 version = "0.3.1"
 description = "Distribution utilities"
@@ -145,7 +135,6 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.7.0,<2.8.0"
 pyflakes = ">=2.3.0,<2.4.0"
@@ -175,7 +164,6 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 flake8 = ">=3.0,<3.2.0 || >3.2.0,<4"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "flake8-simplify"
@@ -188,7 +176,6 @@ python-versions = ">=3.6.1"
 [package.dependencies]
 astor = ">=0.1"
 flake8 = ">=3.7"
-importlib-metadata = {version = ">=0.9", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "flake8-use-fstring"
@@ -226,37 +213,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-name = "importlib-metadata"
-version = "3.10.0"
-description = "Read metadata from Python packages"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
-
-[[package]]
-name = "importlib-resources"
-version = "5.1.2"
-description = "Read resources from Python packages"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-zipp = {version = ">=0.4", markers = "python_version < \"3.8\""}
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "pytest-black (>=0.3.7)", "pytest-mypy"]
-
-[[package]]
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
@@ -292,6 +248,22 @@ description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "mypy"
+version = "0.812"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+typed-ast = ">=1.4.0,<1.5.0"
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
 
 [[package]]
 name = "mypy-extensions"
@@ -336,9 +308,6 @@ category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-
 [package.extras]
 dev = ["pre-commit", "tox"]
 
@@ -353,8 +322,6 @@ python-versions = ">=3.6.1"
 [package.dependencies]
 cfgv = ">=2.0.0"
 identify = ">=1.0.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-importlib-resources = {version = "*", markers = "python_version < \"3.7\""}
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 toml = "*"
@@ -430,7 +397,6 @@ python-versions = ">=3.6"
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<1.0.0a1"
@@ -502,7 +468,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "3.7.4.3"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -531,8 +497,6 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 appdirs = ">=1.4.3,<2"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.0.0,<4"
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-importlib-resources = {version = ">=1.0", markers = "python_version < \"3.7\""}
 six = ">=1.9.0,<2"
 
 [package.extras]
@@ -547,22 +511,10 @@ category = "dev"
 optional = false
 python-versions = "*"
 
-[[package]]
-name = "zipp"
-version = "3.4.1"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
-
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6.1"
-content-hash = "c2dbbd1acf3ee5cce3703d5c9aac0ad7117768de65516980d590d804916ca93e"
+python-versions = "^3.8"
+content-hash = "8dbe08f4038e444b6463701d1c67f4d2259e57ac09eca7b9668ff0bcf52004d4"
 
 [metadata.files]
 appdirs = [
@@ -608,10 +560,6 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
-dataclasses = [
-    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
-    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
-]
 distlib = [
     {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
     {file = "distlib-0.3.1.zip", hash = "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"},
@@ -646,14 +594,6 @@ identify = [
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
-]
-importlib-metadata = [
-    {file = "importlib_metadata-3.10.0-py3-none-any.whl", hash = "sha256:d2d46ef77ffc85cbf7dac7e81dd663fde71c45326131bea8033b9bad42268ebe"},
-    {file = "importlib_metadata-3.10.0.tar.gz", hash = "sha256:c9db46394197244adf2f0b08ec5bc3cf16757e9590b02af1fca085c16c0d600a"},
-]
-importlib-resources = [
-    {file = "importlib_resources-5.1.2-py3-none-any.whl", hash = "sha256:ebab3efe74d83b04d6bf5cd9a17f0c5c93e60fb60f30c90f56265fce4682a469"},
-    {file = "importlib_resources-5.1.2.tar.gz", hash = "sha256:642586fc4740bd1cad7690f836b3321309402b20b332529f25617ff18e8e1370"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -690,6 +630,30 @@ lazy-object-proxy = [
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+mypy = [
+    {file = "mypy-0.812-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521"},
+    {file = "mypy-0.812-cp35-cp35m-win_amd64.whl", hash = "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"},
+    {file = "mypy-0.812-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6"},
+    {file = "mypy-0.812-cp36-cp36m-win_amd64.whl", hash = "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064"},
+    {file = "mypy-0.812-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7"},
+    {file = "mypy-0.812-cp37-cp37m-win_amd64.whl", hash = "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564"},
+    {file = "mypy-0.812-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506"},
+    {file = "mypy-0.812-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5"},
+    {file = "mypy-0.812-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66"},
+    {file = "mypy-0.812-cp38-cp38-win_amd64.whl", hash = "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e"},
+    {file = "mypy-0.812-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97"},
+    {file = "mypy-0.812-cp39-cp39-win_amd64.whl", hash = "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df"},
+    {file = "mypy-0.812-py3-none-any.whl", hash = "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4"},
+    {file = "mypy-0.812.tar.gz", hash = "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -904,8 +868,4 @@ virtualenv = [
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
-]
-zipp = [
-    {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},
-    {file = "zipp-3.4.1.tar.gz", hash = "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gpsoauth"
-version = "0.4.4"
+version = "0.5.0"
 description = "A python client library for Google Play Services OAuth."
 authors = ["Simon Weber <simon@simonmweber.com>"]
 license = "MIT"
@@ -13,16 +13,18 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Typing :: Typed",
 ]
 readme = "README.md"
 homepage = "https://github.com/simon-weber/gpsoauth"
 repository = "https://github.com/simon-weber/gpsoauth"
+include = ["gpsoauth/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
 pycryptodomex = "^3.10.1"
 requests = "^2.25.1"
-importlib-metadata = "^3.10.0"
+urllib3 = "^1.26.4"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.11.1"
@@ -35,6 +37,7 @@ flake8-comprehensions = "^3.4.0"
 flake8-use-fstring = "^1.1"
 flake8-simplify = "^0.14.0"
 pylint = "^2.7.4"
+mypy = "^0.812"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,11 @@ max-line-length = 88
 # W503: Line break occurred before a binary operator
 # E203: Whitespace before ':'
 extend-ignore = E203, W503
+
+[mypy]
+python_version = 3.8
+strict = True
+disallow_any_unimported = True
+show_none_errors = True
+warn_no_return = True
+warn_unreachable = True

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -4,7 +4,7 @@ from gpsoauth.google import construct_signature
 from gpsoauth.util import bytes_to_int, int_to_bytes
 
 
-def test_static_signature():
+def test_static_signature() -> None:
     """Test static signature."""
     username = "someone@google.com"
     password = "apassword"
@@ -13,6 +13,6 @@ def test_static_signature():
     )
 
 
-def test_conversion_roundtrip():
+def test_conversion_roundtrip() -> None:
     """Test key is the same after roundtrip conversion."""
     assert int_to_bytes(bytes_to_int(B64_KEY_7_3_29)) == B64_KEY_7_3_29


### PR DESCRIPTION
- Setup `mypy`.
- Enable strict checks.
- I used modern [PEP 585](https://www.python.org/dev/peps/pep-0585/) type hints, like `dict[str, str]`. Old ones like `Dict` will be deprecated in Python 3.9 and removed completely in 2025. In Python 3.8 this requires `from __future__ import annotations`, this will be enabled by default in Python 3.10. One of the advantages is that these new types don't need to be imported.
- Unfortunately, `urllib3` doesn't export typing information yet, this is tracked by https://github.com/urllib3/urllib3/issues/1897. I'll try to update `gpsoauth` when it's ready.
- Include `py.typed` marker to export all typing information.
- Add `Typing :: Typed` classifier.
- Explicitly add `urllib3` to dependencies list.
- Use standard `importlib.metadata` from Python 3.8.
- Bump version to `0.5.0`.

Closes #26 