### PR TITLE
Setup Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/.github/workflows"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
I don't know if you're interested in this but Dependabot can automatically create PRs which update dependencies on a given schedule. I decided to use conservative weekly interval to not make it very annoying.

It supports Poetry just fine.

It looks like this: https://github.com/leikoilja/ha-google-home/pull/137

Configuration options: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#scheduleinterval