### PR TITLE
Use fixed list of ciphers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gpsoauth"
-version = "0.5.0"
+version = "0.5.1"
 description = "A python client library for Google Play Services OAuth."
 authors = ["Simon Weber <simon@simonmweber.com>"]
 license = "MIT"


### PR DESCRIPTION
Compare to `DEFAULT_CIPHERS` I removed `ECDH+AESGCM` and `DH+AESGCM`, they don't seem to be required. My tests show that all other ciphers are required.

We've got many people who are unable to authorize and get master token: https://github.com/leikoilja/ha-google-home/issues/95

It turns out that other libraries may alter `DEFAULT_CIPHERS`: [example](https://github.com/ollo69/ha-smartthinq-sensors/blob/93fe7a056446d75063043d9221984c80557661c8/custom_components/smartthinq_sensors/wideq/core_v2.py#L117). This has already been fixed that but I think `gpsoauth` shouldn't depend on `DEFAULT_CIPHERS` which may also change in the new releases of `urllib3`.

This will make `gpsoauth` more robust.