### PR TITLE
Add support for logging in via an OAuth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,31 @@ Many thanks to Dima Kovalenko for reverse engineering the EncryptedPasswd signat
 
 For an explanation of recent changes, see [the changelog](https://github.com/simon-weber/gpsoauth/blob/master/CHANGELOG.md).
 
+## Alternative flow
+
+There is an alternative login flow if you are experiencing `BadAuthentication` errors.
+
+1. Login to your Google account (Ex: Via https://accounts.google.com/EmbeddedSetup)
+2. Obtain the value of the `oauth_token` cookie
+3. Perform the token exchange:
+
+```python
+import gpsoauth
+
+email = 'example@gmail.com'
+android_id = '0123456789abcdef'
+token = '...' # insert the oauth_token here
+
+master_response = gpsoauth.exchange_token(email, token, android_id)
+master_token = master_response['Token']
+
+auth_response = gpsoauth.perform_oauth(
+    email, master_token, android_id,
+    service='sj', app='com.google.android.music',
+    client_sig='...')
+token = auth_response['Auth']
+```
+
 ## Ports
 
 - C\#: <https://github.com/vemacs/GPSOAuthSharp>
@@ -44,4 +69,4 @@ For an explanation of recent changes, see [the changelog](https://github.com/sim
 ## Contributing
 
 See [Contributing guidelines](https://github.com/simon-weber/gpsoauth/blob/master/CONTRIBUTING.md).
-This is an open-source project and all countributions are highly welcomed.
+This is an open-source project and all contributions are highly welcomed.

--- a/gpsoauth/__init__.py
+++ b/gpsoauth/__init__.py
@@ -155,6 +155,59 @@ def perform_master_login(
     return _perform_auth_request(data, proxy)
 
 
+def exchange_token(
+    email: str,
+    token: str,
+    android_id: str,
+    service: str = "ac2dm",
+    device_country: str = "us",
+    operator_country: str = "us",
+    lang: str = "en",
+    sdk_version: int = 17,
+    proxy: MutableMapping[str, str] | None = None,
+    client_sig: str = "38918a453d07199354f8b19af05ec6562ced5788",
+) -> dict[str, str]:
+    """
+    Exchanges a Web oauth_token for a master token
+    a Google account.
+    Return a dict, eg::
+        {
+            'Auth': '...',
+            'Email': 'email@gmail.com',
+            'GooglePlusUpgrade': '1',
+            'LSID': '...',
+            'PicasaUser': 'My Name',
+            'RopRevision': '1',
+            'RopText': ' ',
+            'SID': '...',
+            'Token': 'oauth2rt_1/...',
+            'firstName': 'My',
+            'lastName': 'Name',
+            'services': 'hist,mail,googleme,...'
+        }
+    """
+
+    data: dict[str, int | str | bytes] = {
+        "accountType": "HOSTED_OR_GOOGLE",
+        "Email": email,
+        "has_permission": 1,
+        "add_account": 1,
+        "ACCESS_TOKEN": 1,
+        "Token": token,
+        "service": service,
+        "source": "android",
+        "androidId": android_id,
+        "device_country": device_country,
+        "operatorCountry": operator_country,
+        "lang": lang,
+        "sdk_version": sdk_version,
+        "client_sig": client_sig,
+        "callerSig": client_sig,
+        "droidguard_results": "dummy123",
+    }
+
+    return _perform_auth_request(data, proxy)
+
 def perform_oauth(
     email: str,
     master_token: str,

--- a/gpsoauth/__init__.py
+++ b/gpsoauth/__init__.py
@@ -169,7 +169,7 @@ def exchange_token(
 ) -> dict[str, str]:
     """
     Exchanges a web oauth_token for a master token.
-    
+
     Return a dict, eg::
         {
             'Auth': '...',

--- a/gpsoauth/__init__.py
+++ b/gpsoauth/__init__.py
@@ -168,8 +168,8 @@ def exchange_token(
     client_sig: str = "38918a453d07199354f8b19af05ec6562ced5788",
 ) -> dict[str, str]:
     """
-    Exchanges a Web oauth_token for a master token
-    a Google account.
+    Exchanges a web oauth_token for a master token.
+    
     Return a dict, eg::
         {
             'Auth': '...',

--- a/gpsoauth/__init__.py
+++ b/gpsoauth/__init__.py
@@ -208,6 +208,7 @@ def exchange_token(
 
     return _perform_auth_request(data, proxy)
 
+
 def perform_oauth(
     email: str,
     master_token: str,


### PR DESCRIPTION
Relates to https://github.com/simon-weber/gpsoauth/issues/37.

It appears that Google made some changes recently which breaks the standard "master login" flow. In order to fetch a token, the user has to:
1. Visit the URL returned by the service
2. Log into Google
3. Extract the `oauth_token` cookie that is populate
4. Plug this back into `gpsooauth`

Necessary changes determined from https://gitlab.com/AuroraOSS/AuroraStore/-/blob/master/app/src/main/java/com/aurora/store/util/AC2DMTask.kt#L27-43 and tested locally.

Here's some example code, if useful for docs:
```
def auth():
    res = gpsoauth.perform_master_login(email, password)
    if 'Token' in res:
        return res['Token']
    if res.get('Error') == 'NeedsBrowser':
        print('Please authenticate and grab the `oauth_token` cookie:", res.get('Url'))
        token = input("Token: ")
        res = gpsoauth.perform_master_login(email, token, oauth=True)
        if 'Token' in res:
            return res['Token']
        # Fall thru
    print('Error: ', res.get('Error')