### PR TITLE
handle urllib 2.0 changes

### DIFF
--- a/gpsoauth/__init__.py
+++ b/gpsoauth/__init__.py
@@ -14,7 +14,6 @@ from urllib3.poolmanager import PoolManager  # type: ignore[import]
 SSL_DEFAULT_CIPHERS = None
 if version("urllib3") < "2.0.0a1":
     from urllib3.util.ssl_ import DEFAULT_CIPHERS  # type: ignore[import]
-
     SSL_DEFAULT_CIPHERS = DEFAULT_CIPHERS
 
 from . import google

--- a/gpsoauth/__init__.py
+++ b/gpsoauth/__init__.py
@@ -10,7 +10,12 @@ import requests
 
 # Type annotations for urllib3 will be released with v2.
 from urllib3.poolmanager import PoolManager  # type: ignore[import]
-from urllib3.util import ssl_  # type: ignore[import]
+
+SSL_DEFAULT_CIPHERS = None
+if version("urllib3") < "2.0.0a1":
+    from urllib3.util.ssl_ import DEFAULT_CIPHERS  # type: ignore[import]
+
+    SSL_DEFAULT_CIPHERS = DEFAULT_CIPHERS
 
 from . import google
 
@@ -67,7 +72,8 @@ class AuthHTTPAdapter(requests.adapters.HTTPAdapter):
         Authentication.
         """
         context = SSLContext()
-        context.set_ciphers(ssl_.DEFAULT_CIPHERS)
+        if SSL_DEFAULT_CIPHERS:
+            context.set_ciphers(SSL_DEFAULT_CIPHERS)
         context.verify_mode = ssl.CERT_REQUIRED
         context.options &= ~ssl.OP_NO_TICKET  # pylint: disable=E1101
         self.poolmanager = PoolManager(*args, ssl_context=context, **kwargs)


### PR DESCRIPTION
HI,

urllib3 >= 2.0 doesn't define urllib3.util.ssl_.DEFAULT_CIPHERS anymore and this creates an import error in the current gpsoauth code.

This change checks the version and removes the import when not needed 

The removal is documented here: https://urllib3.readthedocs.io/en/stable/changelog.html#removed
"Removed DEFAULT_CIPHERS, HAS_SNI, USE_DEFAULT_SSLCONTEXT_CIPHERS, from the private module urllib3.util.ssl_ (#2168)."

I ran the pre-commit before submiting. One warning related to the google import was still there but I didn't fix it as it wasn't related to teh same issue.

Best,