### PR TITLE
Set explicit Accept-Encoding header

### DIFF
--- a/gpsoauth/__init__.py
+++ b/gpsoauth/__init__.py
@@ -89,8 +89,9 @@ def _perform_auth_request(
         session.proxies = proxies
     session.headers.update(
         {
-            "User-Agent": USER_AGENT,
+            "Accept-Encoding": "identity",
             "Content-type": "application/x-www-form-urlencoded",
+            "User-Agent": USER_AGENT,
         }
     )
 


### PR DESCRIPTION
I found that sometimes urllib3 may add extra headers which can cause `NeedsBrowser` error. This won't help with `BadAuthentication` but may help with `NeedsBrowser` for some users.

This is list of headers urllib3 can set automatically:
https://github.com/urllib3/urllib3/blob/f7cd7f3f632cf5224f627536f02c2abf7e4146d1/src/urllib3/util/request.py#L19

Same host, same terminal tab (same env), same Python (not just version, exactly the same installation), same versions of `requests`, `urllib3`, `certify`, `pycryptodomex`.
Different virtual envs and terminal tabs.

Working:
```
Hypertext Transfer Protocol
    POST /auth HTTP/1.1\r\n
    Host: android.clients.google.com\r\n
    Accept-Encoding: identity\r\n
    User-Agent: GoogleAuth/1.4\r\n
    Content-type: application/x-www-form-urlencoded\r\n
    Content-Length: 541\r\n
    \r\n
    [Full request URI: https://android.clients.google.com/auth]
    [HTTP request 1/1]
    [Response in frame: 25]
    File Data: 541 bytes
```

Failing with `NeedsBrowser`:
```
Hypertext Transfer Protocol
    POST /auth HTTP/1.1\r\n
    Host: android.clients.google.com\r\n
    User-Agent: GoogleAuth/1.4\r\n
    Accept-Encoding: gzip, deflate\r\n
    Accept: */*\r\n
    Connection: keep-alive\r\n
    Content-type: application/x-www-form-urlencoded\r\n
    Content-Length: 541\r\n
    \r\n
    [Full request URI: https://android.clients.google.com/auth]
    [HTTP request 1/1]
    [Response in frame: 27]
    File Data: 541 bytes
```