### PR TITLE
Adding context.load_default_certs() to fix SSL failures

### DIFF
--- a/gpsoauth/__init__.py
+++ b/gpsoauth/__init__.py
@@ -77,6 +77,7 @@ class AuthHTTPAdapter(requests.adapters.HTTPAdapter):
             context.set_ciphers(SSL_DEFAULT_CIPHERS)
         context.verify_mode = ssl.CERT_REQUIRED
         context.options &= ~ssl.OP_NO_TICKET  # pylint: disable=E1101
+        context.load_default_certs()
         self.poolmanager = PoolManager(*args, ssl_context=context, **kwargs)
 
 


### PR DESCRIPTION
As recommended [here](https://github.com/leikoilja/ha-google-home/issues/876#issuecomment-2155921529) and [here](https://github.com/simon-weber/gpsoauth/issues/57#issuecomment-2138417357)

We are seeing consistent failures without this.